### PR TITLE
Fix webconfig filename case

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -1,4 +1,4 @@
-#include "configs/WebConfig.h"
+#include "configs/webconfig.h"
 
 #include "storagemanager.h"
 #include "configmanager.h"


### PR DESCRIPTION
Building on Linux broke due to the case mismatch between "webconfig" and
"WebConfig".