### PR TITLE
Update BoardConfig.h

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -68,6 +68,6 @@
 #define I2C_SDA_PIN 0
 #define I2C_SCL_PIN 1
 #define I2C_BLOCK i2c0
-#define I2C_SPEED 800000
+#define I2C_SPEED 100000
 
 #endif

--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -68,6 +68,6 @@
 #define I2C_SDA_PIN 0
 #define I2C_SCL_PIN 1
 #define I2C_BLOCK i2c0
-#define I2C_SPEED 100000
+#define I2C_SPEED 400000
 
 #endif


### PR DESCRIPTION
Reduced the default I2C_SPEED from 800000 to 100000.

This fixes as issue where if buttons that trigger an SOCD rule are held they will no longer flicker on the OLED display.  

This also fixes an issue where 2.42" OLED displays would have some artifacting and would eventually go blank after some time.

This has been tested and is working on the latest version.