### PR TITLE
Fixed Player LEDs in the NeoPico LED code

### DIFF
--- a/src/addons/neopicoleds.cpp
+++ b/src/addons/neopicoleds.cpp
@@ -122,6 +122,8 @@ void NeoPicoLEDAddon::process()
 		switch (gamepad->options.inputMode) {
 			case INPUT_MODE_XINPUT:
 				animationState = getXInputAnimationNEOPICO(featureData);
+				if (neoPLEDs != nullptr && animationState.animation != PLED_ANIM_NONE)
+					neoPLEDs->animate(animationState);
 				break;
 		}
 	}


### PR DESCRIPTION
This code fixes the player LEDs in the NeoPico LED code. I missed 2 lines when I was porting the code over, easy fix.

The following is an example taken from the Crush Counter code:

#define PLED_TYPE PLED_TYPE_RGB
#define PLED1_PIN 12
#define PLED2_PIN 13
#define PLED3_PIN 14
#define PLED4_PIN 15
