### PR TITLE
Add Addon Reverse Input

### DIFF
--- a/configs/BentoBox/BoardConfig.h
+++ b/configs/BentoBox/BoardConfig.h
@@ -36,6 +36,7 @@
 #define PIN_BUTTON_A1   20          // A1 / Guide / Home / ~ / 13 / ~
 #define PIN_BUTTON_A2   19          // A2 / ~ / Capture / ~ / 14 / ~
 #define PIN_BUTTON_TURBO -1         // Turbo
+#define PIN_BUTTON_REVERSE -1         // UDLR Reverse
 #define PIN_SLIDER_LS    -1         // Left Stick Slider
 #define PIN_SLIDER_RS    -1         // Right Stick Slider
 

--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -36,6 +36,7 @@
 #define PIN_BUTTON_A1   20          // A1 / Guide / Home / ~ / 13 / ~
 #define PIN_BUTTON_A2   21          // A2 / ~ / Capture / ~ / 14 / ~
 #define PIN_BUTTON_TURBO 14         // Turbo
+#define PIN_BUTTON_REVERSE 22       // UDLR Reverse
 #define PIN_SLIDER_LS    -1         // Left Stick Slider
 #define PIN_SLIDER_RS    -1         // Right Stick Slider
 
@@ -121,6 +122,10 @@
 #define ANALOG_ADC_VRY -1
 
 
+// Reverse Button section
+#define REVERSE_LED_PIN 12
+
+
 // This is the I2C Display section (commonly known as the OLED display section).
 // In this section you can specify if a display as been enabled, which pins are assined to it, the block address and speed.
 // The default for `HAS_I2C_DISPLAY` is `1` which enables it.
@@ -173,6 +178,11 @@
 #define I2C_SPEED 400000
 #define DISPLAY_FLIP 0
 #define DISPLAY_INVERT 0
+
+#define REVERSE_UP_DEFAULT 1
+#define REVERSE_DOWN_DEFAULT 1
+#define REVERSE_LEFT_DEFAULT 1
+#define REVERSE_RIGHT_DEFAULT 1
 
 #define BUTTON_LAYOUT BUTTON_LAYOUT_STICK
 #define BUTTON_LAYOUT_RIGHT BUTTON_LAYOUT_VEWLIX

--- a/include/inputs/reverse.h
+++ b/include/inputs/reverse.h
@@ -24,6 +24,8 @@ private:
 
 	bool state;
 
+	bool useLED;
+
 	GamepadButtonMapping *mapDpadUp;
 	GamepadButtonMapping *mapDpadDown;
 	GamepadButtonMapping *mapDpadLeft;

--- a/include/inputs/reverse.h
+++ b/include/inputs/reverse.h
@@ -24,7 +24,7 @@ private:
 
 	bool state;
 
-	bool useLED;
+	uint8_t pinLED;
 
 	GamepadButtonMapping *mapDpadUp;
 	GamepadButtonMapping *mapDpadDown;

--- a/include/inputs/reverse.h
+++ b/include/inputs/reverse.h
@@ -1,0 +1,42 @@
+#ifndef _Reverse_H
+#define _Reverse_H
+
+#include "gpaddon.h"
+
+#include "GamepadEnums.h"
+
+#ifndef PIN_REVERSE
+#define PIN_REVERSE     -1
+#endif
+
+// Reverse Module Name
+#define ReverseName "Input Reverse"
+
+class ReverseInput : public GPAddon {
+public:
+	virtual bool available();   // GPAddon available
+	virtual void setup();       // Reverse Button Setup
+	virtual void process();     // Reverse process
+    virtual std::string name() { return ReverseName; }
+private:
+    void update();
+    uint8_t input(uint8_t valueMask, uint16_t buttonMask, uint16_t buttonMaskReverse, uint8_t action, bool invertAxis);
+
+	bool state;
+
+	GamepadButtonMapping *mapDpadUp;
+	GamepadButtonMapping *mapDpadDown;
+	GamepadButtonMapping *mapDpadLeft;
+	GamepadButtonMapping *mapDpadRight;
+
+	bool invertXAxis;
+	bool invertYAxis;
+
+    // 0 - Ignore, 1 - Enabled, 2 - Neutral
+    uint8_t actionUp;
+    uint8_t actionDown;
+    uint8_t actionLeft;
+    uint8_t actionRight;
+};
+
+#endif // _Reverse_H_

--- a/include/storagemanager.h
+++ b/include/storagemanager.h
@@ -44,6 +44,7 @@ struct BoardOptions
 	uint8_t pinButtonA1;
 	uint8_t pinButtonA2;
 	uint8_t pinButtonTurbo;
+	uint8_t pinButtonReverse;
 	uint8_t pinSliderLS;
 	uint8_t pinSliderRS;
 	ButtonLayout buttonLayout;
@@ -58,6 +59,11 @@ struct BoardOptions
 	bool displayInvert;
 	uint8_t turboShotCount; // Turbo
 	uint8_t pinTurboLED;    // Turbo LED
+	uint8_t pinReverseLED;    // Reverse LED
+	uint8_t reverseActionUp;
+	uint8_t reverseActionDown;
+	uint8_t reverseActionLeft;
+	uint8_t reverseActionRight;
 	char boardVersion[32]; // 32-char limit to board name
 	uint32_t checksum;
 };

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -391,6 +391,12 @@ std::string setAddonOptions()
 	boardOptions.pinSliderLS  		= doc["sliderLSPin"] == -1 ? 0xFF : doc["sliderLSPin"];
 	boardOptions.pinSliderRS  		= doc["sliderRSPin"] == -1 ? 0xFF : doc["sliderRSPin"];
 	boardOptions.turboShotCount 	= doc["turboShotCount"];
+	boardOptions.pinButtonReverse  	= doc["reversePin"] == -1 ? 0xFF : doc["reversePin"];
+	boardOptions.pinReverseLED  	= doc["reversePinLED"] == -1 ? 0xFF : doc["reversePinLED"];
+	boardOptions.reverseActionUp  	= doc["reverseActionUp"] == -1 ? 0xFF : doc["reverseActionUp"];
+	boardOptions.reverseActionDown  = doc["reverseActionDown"] == -1 ? 0xFF : doc["reverseActionDown"];
+	boardOptions.reverseActionLeft  = doc["reverseActionLeft"] == -1 ? 0xFF : doc["reverseActionLeft"];
+	boardOptions.reverseActionRight = doc["reverseActionRight"] == -1 ? 0xFF : doc["reverseActionRight"];
 	Storage::getInstance().setBoardOptions(boardOptions);
 
 	return serialize_json(doc);
@@ -405,6 +411,12 @@ std::string getAddonOptions()
 	doc["sliderLSPin"] = boardOptions.pinSliderLS == 0xFF ? -1 : boardOptions.pinSliderLS;
 	doc["sliderRSPin"] = boardOptions.pinSliderRS == 0xFF ? -1 : boardOptions.pinSliderRS;
 	doc["turboShotCount"] = boardOptions.turboShotCount;
+	doc["reversePin"] = boardOptions.pinButtonReverse == 0xFF ? -1 : boardOptions.pinButtonReverse;
+	doc["reversePinLED"] = boardOptions.pinReverseLED == 0xFF ? -1 : boardOptions.pinReverseLED;
+	doc["reverseActionUp"] = boardOptions.reverseActionUp == 0xFF ? -1 : boardOptions.reverseActionUp;
+	doc["reverseActionDown"] = boardOptions.reverseActionDown == 0xFF ? -1 : boardOptions.reverseActionDown;
+	doc["reverseActionLeft"] = boardOptions.reverseActionLeft == 0xFF ? -1 : boardOptions.reverseActionLeft;
+	doc["reverseActionRight"] = boardOptions.reverseActionRight == 0xFF ? -1 : boardOptions.reverseActionRight;
 
 	Gamepad * gamepad = Storage::getInstance().GetGamepad();
 	auto usedPins = doc.createNestedArray("usedPins");

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -7,6 +7,7 @@
 #include "inputs/analog.h" // Inputs
 #include "inputs/jslider.h"
 #include "inputs/turbo.h"
+#include "inputs/reverse.h"
 
 // Pico includes
 #include "pico/bootrom.h"
@@ -59,6 +60,7 @@ void GP2040::setup() {
 	setupInput(new AnalogInput());
 	setupInput(new JSliderInput());
 	setupInput(new TurboInput());
+	setupInput(new ReverseInput());
 }
 
 void GP2040::run() {

--- a/src/inputs/reverse.cpp
+++ b/src/inputs/reverse.cpp
@@ -1,0 +1,62 @@
+#include "inputs/reverse.h"
+#include "storagemanager.h"
+#include "GamepadEnums.h"
+
+bool ReverseInput::available() {
+    BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
+	return (boardOptions.pinButtonReverse != (uint8_t)-1);
+}
+
+void ReverseInput::setup()
+{
+    // Setup Reverse Input Button
+    BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
+    gpio_init(boardOptions.pinButtonReverse);             // Initialize pin
+    gpio_set_dir(boardOptions.pinButtonReverse, GPIO_IN); // Set as INPUT
+    gpio_pull_up(boardOptions.pinButtonReverse);          // Set as PULLUP
+
+    actionUp = boardOptions.reverseActionUp;
+    actionDown = boardOptions.reverseActionDown;
+    actionLeft = boardOptions.reverseActionLeft;
+    actionRight = boardOptions.reverseActionDown;
+
+    Gamepad * gamepad = Storage::getInstance().GetGamepad();
+	mapDpadUp    = gamepad->mapDpadUp;
+	mapDpadDown  = gamepad->mapDpadDown;
+	mapDpadLeft  = gamepad->mapDpadLeft;
+	mapDpadRight = gamepad->mapDpadRight;
+
+    invertXAxis = gamepad->options.invertXAxis;
+    invertYAxis = gamepad->options.invertYAxis;
+
+    state = false;
+}
+
+void ReverseInput::update() {
+    BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
+    state = !gpio_get(boardOptions.pinButtonReverse);
+}
+
+uint8_t ReverseInput::input(uint8_t valueMask, uint16_t buttonMask, uint16_t buttonMaskReverse, uint8_t action, bool invertAxis) {
+    if (state && action == 2) {
+        return 0;
+    }
+    bool invert = (state && action == 1) ? !invertAxis : invertAxis;
+    return (valueMask ? (invert ? buttonMaskReverse : buttonMask) : 0);
+}
+
+void ReverseInput::process()
+{
+    // Update Reverse State
+    update();
+
+    uint32_t values = ~gpio_get_all();
+    Gamepad * gamepad = Storage::getInstance().GetGamepad();
+
+    gamepad->state.dpad = 0
+        | input(values & mapDpadUp->pinMask,    mapDpadUp->buttonMask,      mapDpadDown->buttonMask,    actionUp,       invertYAxis)
+        | input(values & mapDpadDown->pinMask,  mapDpadDown->buttonMask,    mapDpadUp->buttonMask,      actionDown,     invertYAxis)
+        | input(values & mapDpadLeft->pinMask,  mapDpadLeft->buttonMask,    mapDpadRight->buttonMask,   actionLeft,     invertXAxis)
+        | input(values & mapDpadRight->pinMask, mapDpadRight->buttonMask,   mapDpadLeft->buttonMask,    actionRight,    invertXAxis)
+    ;
+}

--- a/src/inputs/reverse.cpp
+++ b/src/inputs/reverse.cpp
@@ -68,6 +68,6 @@ void ReverseInput::process()
     ;
     
     if (pinLED != -1) {
-        gpio_put(pinLED, state);
+        gpio_put(pinLED, !state);
     }
 }

--- a/src/inputs/reverse.cpp
+++ b/src/inputs/reverse.cpp
@@ -14,6 +14,13 @@ void ReverseInput::setup()
     gpio_init(boardOptions.pinButtonReverse);             // Initialize pin
     gpio_set_dir(boardOptions.pinButtonReverse, GPIO_IN); // Set as INPUT
     gpio_pull_up(boardOptions.pinButtonReverse);          // Set as PULLUP
+    
+    pinLED = boardOptions.pinReverseLED;
+    if (pinLED != -1) {
+        gpio_init(boardOptions.pinReverseLED);
+        gpio_set_dir(boardOptions.pinReverseLED, GPIO_OUT);
+        gpio_put(boardOptions.pinReverseLED, 1);
+    }
 
     actionUp = boardOptions.reverseActionUp;
     actionDown = boardOptions.reverseActionDown;
@@ -59,4 +66,8 @@ void ReverseInput::process()
         | input(values & mapDpadLeft->pinMask,  mapDpadLeft->buttonMask,    mapDpadRight->buttonMask,   actionLeft,     invertXAxis)
         | input(values & mapDpadRight->pinMask, mapDpadRight->buttonMask,   mapDpadLeft->buttonMask,    actionRight,    invertXAxis)
     ;
+    
+    if (pinLED != -1) {
+        gpio_put(pinLED, state);
+    }
 }

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -61,6 +61,7 @@ void Storage::setDefaultBoardOptions()
 	boardOptions.pinButtonA1       = PIN_BUTTON_A1;
 	boardOptions.pinButtonA2       = PIN_BUTTON_A2;
 	boardOptions.pinButtonTurbo    = PIN_BUTTON_TURBO;
+	boardOptions.pinButtonReverse  = PIN_BUTTON_REVERSE;
 	boardOptions.pinSliderLS       = PIN_SLIDER_LS;
 	boardOptions.pinSliderRS       = PIN_SLIDER_RS;
 	boardOptions.buttonLayout      = BUTTON_LAYOUT;
@@ -75,6 +76,11 @@ void Storage::setDefaultBoardOptions()
 	boardOptions.displayInvert     = DISPLAY_INVERT;
 	boardOptions.turboShotCount    = DEFAULT_SHOT_PER_SEC;
 	boardOptions.pinTurboLED       = TURBO_LED_PIN;
+	boardOptions.pinReverseLED     = REVERSE_LED_PIN;
+	boardOptions.reverseActionUp         = REVERSE_UP_DEFAULT;
+	boardOptions.reverseActionDown       = REVERSE_DOWN_DEFAULT;
+	boardOptions.reverseActionLeft       = REVERSE_LEFT_DEFAULT;
+	boardOptions.reverseActionRight      = REVERSE_RIGHT_DEFAULT;
 	strncpy(boardOptions.boardVersion, GP2040VERSION, strlen(GP2040VERSION));
 	setBoardOptions(boardOptions);
 }

--- a/www/src/Pages/AddonsConfigPage.js
+++ b/www/src/Pages/AddonsConfigPage.js
@@ -3,6 +3,7 @@ import { Button, Form, Row, Col } from 'react-bootstrap';
 import { Formik, useFormikContext } from 'formik';
 import * as yup from 'yup';
 import FormControl from '../Components/FormControl';
+import FormSelect from '../Components/FormSelect';
 import Section from '../Components/Section';
 import WebApi from '../Services/WebApi';
 
@@ -12,6 +13,8 @@ const schema = yup.object().shape({
 	sliderLSPin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Slider LS Pin'),
 	sliderRSPin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Slider RS Pin'),
 	turboShotCount: yup.number().required().min(5).max(30).label('Turbo Shot Count'),
+	reversePin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Reverse Pin'),
+	reversePinLED: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Reverse Pin LED'),
 });
 
 const defaultValues = {
@@ -19,8 +22,16 @@ const defaultValues = {
 	turboPinLED: -1,
 	sliderLSPin: -1,
 	sliderRSPin: -1,
-	turboShotCount: 5
+	turboShotCount: 5,
+	reversePin: -1,
+	reversePinLED: -1
 };
+
+const REVERSE_ACTION = [
+	{ label: 'Disable', value: 0 },
+	{ label: 'Enable', value: 1 },
+	{ label: 'Neutral', value: 2 },
+];
 
 let usedPins = [];
 
@@ -47,6 +58,18 @@ const FormContext = () => {
 			values.sliderRSPin = parseInt(values.sliderRSPin);
 		if (!!values.turboShotCount)
 			values.turboShotCount = parseInt(values.turboShotCount);
+		if (!!values.reversePin)
+			values.reversePin = parseInt(values.reversePin);
+		if (!!values.reversePinLED)
+			values.reversePinLED = parseInt(values.reversePinLED);
+		if (!!values.reverseActionUp)
+			values.reverseActionUp = parseInt(values.reverseActionUp);
+		if (!!values.reverseActionDown)
+			values.reverseActionDown = parseInt(values.reverseActionDown);
+		if (!!values.reverseActionLeft)
+			values.reverseActionLeft = parseInt(values.reverseActionLeft);
+		if (!!values.reverseActionRight)
+			values.reverseActionRight = parseInt(values.reverseActionRight);
 	}, [values, setValues]);
 
 	return null;
@@ -70,11 +93,13 @@ export default function AddonsConfigPage() {
 				touched,
 				errors,
 			}) => (
-				<Section title="Add-Ons Configuration">
-					<p>Use the form below to reconfigure experimental options in GP2040-CE.</p>
-					<p>Please note: these options are experimental for the time being.</p>
-					<Form noValidate onSubmit={handleSubmit}>
-						<Row>
+				<Form noValidate onSubmit={handleSubmit}>
+					<Section title="Add-Ons Configuration">
+						<p>Use the form below to reconfigure experimental options in GP2040-CE.</p>
+						<p>Please note: these options are experimental for the time being.</p>
+					</Section>
+					<Section title="Turbo">
+						<Col>
 							<FormControl type="number"
 								label="Turbo Pin"
 								name="turboPin"
@@ -100,6 +125,22 @@ export default function AddonsConfigPage() {
 								max={29}
 							/>
 							<FormControl type="number"
+								label="Turbo Shot Count"
+								name="turboShotCount"
+								className="form-control-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.turboShotCount}
+								error={errors.turboShotCount}
+								isInvalid={errors.turboShotCount}
+								onChange={handleChange}
+								min={2}
+								max={30}
+							/>
+						</Col>
+					</Section>
+					<Section title="Slider">
+						<Col>
+							<FormControl type="number"
 								label="Slider LS Pin"
 								name="sliderLSPin"
 								className="form-select-sm"
@@ -123,26 +164,90 @@ export default function AddonsConfigPage() {
 								min={-1}
 								max={29}
 							/>
+						</Col>
+					</Section>
+					<Section title="Input Reverse">
+						<Col>
 							<FormControl type="number"
-								label="Turbo Shot Count"
-								name="turboShotCount"
-								className="form-control-sm"
+								label="Reverse Input Pin"
+								name="reversePin"
+								className="form-select-sm"
 								groupClassName="col-sm-3 mb-3"
-								value={values.turboShotCount}
-								error={errors.turboShotCount}
-								isInvalid={errors.turboShotCount}
+								value={values.reversePin}
+								error={errors.reversePin}
+								isInvalid={errors.reversePin}
 								onChange={handleChange}
-								min={2}
-								max={30}
+								min={-1}
+								max={29}
 							/>
-						</Row>
-						<div className="mt-3">
-							<Button type="submit">Save</Button>
-							{saveMessage ? <span className="alert">{saveMessage}</span> : null}
-						</div>
-						<FormContext />
-					</Form>
-				</Section>
+							<FormControl type="number"
+								label="Reverse Input Pin LED"
+								name="reversePinLED"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.reversePinLED}
+								error={errors.reversePinLED}
+								isInvalid={errors.reversePinLED}
+								onChange={handleChange}
+								min={-1}
+								max={29}
+							/>
+							<FormSelect
+								label="Reverse Up"
+								name="reverseActionUp"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.reverseActionUp}
+								error={errors.reverseActionUp}
+								isInvalid={errors.reverseActionUp}
+								onChange={handleChange}
+							>
+								{REVERSE_ACTION.map((o, i) => <option key={`reverseActionUp-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Reverse Down"
+								name="reverseActionDown"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.reverseActionDown}
+								error={errors.reverseActionDown}
+								isInvalid={errors.reverseActionDown}
+								onChange={handleChange}
+							>
+								{REVERSE_ACTION.map((o, i) => <option key={`reverseActionDown-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Reverse Left"
+								name="reverseActionLeft"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.reverseActionLeft}
+								error={errors.reverseActionLeft}
+								isInvalid={errors.reverseActionLeft}
+								onChange={handleChange}
+							>
+								{REVERSE_ACTION.map((o, i) => <option key={`reverseActionLeft-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Reverse Right"
+								name="reverseActionRight"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.reverseActionRight}
+								error={errors.reverseActionRight}
+								isInvalid={errors.reverseActionRight}
+								onChange={handleChange}
+							>
+								{REVERSE_ACTION.map((o, i) => <option key={`reverseActionRight-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+						</Col>
+					</Section>
+					<div className="mt-3">
+						<Button type="submit">Save</Button>
+						{saveMessage ? <span className="alert">{saveMessage}</span> : null}
+					</div>
+					<FormContext />
+				</Form>
 			)}
 		</Formik>
 	);


### PR DESCRIPTION
Adds support for using an additional GPIO pin for allowing inputs to be reverse on button command.

3 settings per direction:
Disabled - Default input with no modifiers
Enabled - Input is modified when the reverse button is pressed
Neutral - Pressing the reverse button sets input to center

Addon page is updated for better organization.