### PR TITLE
Sparkfun & Waveshare configs: Add missing reverse defines

### DIFF
--- a/configs/SparkFunProMicro/BoardConfig.h
+++ b/configs/SparkFunProMicro/BoardConfig.h
@@ -30,6 +30,7 @@
 #define PIN_BUTTON_R3 -1   // R3 / RS    / RS      / R3       / 12 / RS
 #define PIN_BUTTON_A1 7    // A1 / Guide / Home    / ~        / 13 / ~
 #define PIN_BUTTON_A2 8    // A2 / ~     / Capture / ~        / 14 / ~
+#define PIN_BUTTON_REVERSE -1 // UDLR Reverse
 #define PIN_BUTTON_TURBO 9 // Turbo
 #define PIN_SLIDER_LS -1   // Left Stick Slider
 #define PIN_SLIDER_RS -1   // Right Stick Slider
@@ -111,6 +112,9 @@
 #define ANALOG_ADC_VRX -1
 #define ANALOG_ADC_VRY -1
 
+// Reverse Button section
+#define REVERSE_LED_PIN -1
+
 // This is the I2C Display section (commonly known as the OLED display section).
 // In this section you can specify if a display as been enabled, which pins are assined to it, the block address and speed.
 // The default for `HAS_I2C_DISPLAY` is `1` which enables it.
@@ -163,6 +167,11 @@
 #define I2C_SPEED 400000
 #define DISPLAY_FLIP 0
 #define DISPLAY_INVERT 0
+
+#define REVERSE_UP_DEFAULT 1
+#define REVERSE_DOWN_DEFAULT 1
+#define REVERSE_LEFT_DEFAULT 1
+#define REVERSE_RIGHT_DEFAULT 1
 
 #define BUTTON_LAYOUT BUTTON_LAYOUT_STICK
 #define BUTTON_LAYOUT_RIGHT BUTTON_LAYOUT_VEWLIX

--- a/configs/WaveshareZero/BoardConfig.h
+++ b/configs/WaveshareZero/BoardConfig.h
@@ -35,7 +35,8 @@
 #define PIN_BUTTON_R3   27          // R3 / RS / RS / R3 / 12 / RS
 #define PIN_BUTTON_A1   14          // A1 / Guide / Home / ~ / 13 / ~
 #define PIN_BUTTON_A2   15          // A2 / ~ / Capture / ~ / 14 / ~
-#define PIN_BUTTON_TURBO 29          // Turbo
+#define PIN_BUTTON_TURBO 29         // Turbo
+#define PIN_BUTTON_REVERSE -1       // UDLR Reverse
 #define PIN_SLIDER_LS    -1         // Left Stick Slider
 #define PIN_SLIDER_RS    -1         // Right Stick Slider
 
@@ -120,6 +121,8 @@
 #define ANALOG_ADC_VRX -1
 #define ANALOG_ADC_VRY -1
 
+// Reverse Button section
+#define REVERSE_LED_PIN -1
 
 // This is the I2C Display section (commonly known as the OLED display section).
 // In this section you can specify if a display as been enabled, which pins are assined to it, the block address and speed.
@@ -173,6 +176,11 @@
 #define I2C_SPEED 400000
 #define DISPLAY_FLIP 0
 #define DISPLAY_INVERT 0
+
+#define REVERSE_UP_DEFAULT 1
+#define REVERSE_DOWN_DEFAULT 1
+#define REVERSE_LEFT_DEFAULT 1
+#define REVERSE_RIGHT_DEFAULT 1
 
 #define BUTTON_LAYOUT BUTTON_LAYOUT_STICK
 #define BUTTON_LAYOUT_RIGHT BUTTON_LAYOUT_VEWLIX


### PR DESCRIPTION
I was compiling firmware for my Pro Micro RP2040 & Waveshare Zero boards and these missing defines were causing the builds to fail. I assume its related to https://github.com/OpenStickFoundation/GP2040-CE/pull/101