### PR TITLE
Board config fix, this should allow all board configs to build again

### DIFF
--- a/include/inputs/analog.h
+++ b/include/inputs/analog.h
@@ -10,7 +10,7 @@
 #endif
 
 #ifndef ANALOG_ADC_VRY
-#define ANALOG_ADC_VRX    -1
+#define ANALOG_ADC_VRY    -1
 #endif
 
 // Analog Module Name

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -19,6 +19,7 @@
 #include "addons/neopicoleds.h"
 #include "addons/playerleds.h"
 
+#include "inputs/i2canalog1219.h"
 #include "inputs/turbo.h"
 
 #include "helper.h"


### PR DESCRIPTION
Quick fix to include board config pins when they are undefined into the code.

This will allow ALL current board configs to build in latest.