### PR TITLE
Add SH1106 Display compatibility

### DIFF
--- a/configs/Pico/BoardConfig.h
+++ b/configs/Pico/BoardConfig.h
@@ -174,6 +174,7 @@
 #define I2C_SPEED 400000
 #define DISPLAY_FLIP 0
 #define DISPLAY_INVERT 0
+#define DISPLAY_SH1106 0
 
 // I2C Analog ADS1219 Add-on Options
 #define I2C_ANALOG1219_SDA_PIN -1

--- a/include/addons/i2cdisplay.h
+++ b/include/addons/i2cdisplay.h
@@ -53,6 +53,10 @@
 #define DISPLAY_USEWIRE 1
 #endif
 
+#ifndef DISPLAY_SH1106
+#define DISPLAY_SH1106 0
+#endif
+
 // i2c Display Module
 #define I2CDisplayName "I2CDisplay"
 

--- a/include/storagemanager.h
+++ b/include/storagemanager.h
@@ -56,6 +56,7 @@ struct BoardOptions
 	uint8_t displaySize;
 	bool displayFlip;
 	bool displayInvert;
+    bool displaySh1106;
 	uint8_t turboShotCount; // Turbo
 	uint8_t pinTurboLED;    // Turbo LED
 	uint8_t pinReverseLED;    // Reverse LED

--- a/src/addons/i2cdisplay.cpp
+++ b/src/addons/i2cdisplay.cpp
@@ -17,6 +17,9 @@ bool I2CDisplayAddon::available() {
 
 void I2CDisplayAddon::setup() {
 	BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
+    if (boardOptions.displaySh1106 == true) {
+        boardOptions.displaySize = OLED_132x64;
+    }
 	obdI2CInit(&obd,
 	    boardOptions.displaySize,
 		boardOptions.displayI2CAddress,

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -74,6 +74,7 @@ void Storage::setDefaultBoardOptions()
 	boardOptions.displaySize       = DISPLAY_SIZE;
 	boardOptions.displayFlip       = DISPLAY_FLIP;
 	boardOptions.displayInvert     = DISPLAY_INVERT;
+    boardOptions.displaySh1106     = DISPLAY_SH1106;
 	boardOptions.turboShotCount    = DEFAULT_SHOT_PER_SEC;
 	boardOptions.pinTurboLED       = TURBO_LED_PIN;
 	boardOptions.pinReverseLED     = REVERSE_LED_PIN;


### PR DESCRIPTION
This needs a lot of work, feel free to close and remake this. This essentially adds support to SH1106 based displays.
While previous versions of OneBitDisplay once auto-detected the display type it is no longer the case.
Essentially the issue has to do with the SH1106 being made for 132x64 displays. The available screen is still 128x64, though it addresses those bits to somewhere we cannot see and takes random trash from RAM to populate the last two columns. These screens are most often labeled as SSD1306 and often leads to what we see very often. 