### PR TITLE
Issue #157 bug fix. The storagemanager SDA/SCL pins were set to int b…

### DIFF
--- a/include/storagemanager.h
+++ b/include/storagemanager.h
@@ -47,9 +47,9 @@ struct BoardOptions
 	uint8_t pinSliderLS;
 	uint8_t pinSliderRS;
 	ButtonLayout buttonLayout;
-	int i2cSDAPin;
-	int i2cSCLPin;
-	int i2cBlock;
+	uint8_t i2cSDAPin;
+	uint8_t i2cSCLPin;
+	uint8_t i2cBlock;
 	uint32_t i2cSpeed;
 	bool hasI2CDisplay;
 	int displayI2CAddress;
@@ -63,8 +63,8 @@ struct BoardOptions
 	uint8_t reverseActionDown;
 	uint8_t reverseActionLeft;
 	uint8_t reverseActionRight;
-	int i2cAnalog1219SDAPin;
-	int i2cAnalog1219SCLPin;
+	uint8_t i2cAnalog1219SDAPin;
+	uint8_t i2cAnalog1219SCLPin;
 	int i2cAnalog1219Block;
 	uint32_t i2cAnalog1219Speed;
 	uint8_t i2cAnalog1219Address;

--- a/src/addons/i2canalog1219.cpp
+++ b/src/addons/i2canalog1219.cpp
@@ -6,8 +6,8 @@
 
 bool I2CAnalog1219Input::available() {
     BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
-	return (boardOptions.i2cAnalog1219SDAPin != -1 &&
-        boardOptions.i2cAnalog1219SCLPin != -1);
+	return (boardOptions.i2cAnalog1219SDAPin != (uint8_t)-1 &&
+        boardOptions.i2cAnalog1219SCLPin != (uint8_t)-1);
 }
 
 void I2CAnalog1219Input::setup() {

--- a/src/addons/i2cdisplay.cpp
+++ b/src/addons/i2cdisplay.cpp
@@ -12,7 +12,9 @@
 
 bool I2CDisplayAddon::available() {
 	BoardOptions boardOptions = Storage::getInstance().getBoardOptions();
-	return boardOptions.hasI2CDisplay && boardOptions.i2cSDAPin != -1 && boardOptions.i2cSCLPin != -1;
+	return boardOptions.hasI2CDisplay && 
+		boardOptions.i2cSDAPin != (uint8_t)-1 && 
+		boardOptions.i2cSCLPin != (uint8_t)-1;
 }
 
 void I2CDisplayAddon::setup() {


### PR DESCRIPTION
Several options should have been uint8_t. Also added uint8_t casting when checking for -1.