### PR TITLE
Fix Linux support for WebConfigurator

### DIFF
--- a/lib/TinyUSB_Gamepad/include/webserver_descriptors.h
+++ b/lib/TinyUSB_Gamepad/include/webserver_descriptors.h
@@ -22,13 +22,15 @@ static const uint8_t webserver_string_language[]     = { 0x09, 0x04 };
 static const uint8_t webserver_string_manufacturer[] = "TinyUSB";
 static const uint8_t webserver_string_product[]      = "USB Webserver";
 static const uint8_t webserver_string_version[]      = "1.0";
+static const uint8_t webserver_string_interface[]    = "TinyUSB Network Interface";
 
 static const uint8_t *webserver_string_descriptors[] =
 {
 	webserver_string_language,
 	webserver_string_manufacturer,
 	webserver_string_product,
-	webserver_string_version
+	webserver_string_version,
+	webserver_string_interface
 };
 
 static const tusb_desc_device_t webserver_device_descriptor =

--- a/lib/TinyUSB_Gamepad/include/webserver_descriptors.h
+++ b/lib/TinyUSB_Gamepad/include/webserver_descriptors.h
@@ -47,7 +47,7 @@ static const tusb_desc_device_t webserver_device_descriptor =
 	.bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
 
 	.idVendor           = 0xCAFE,
-	.idProduct          = 0x4001,
+	.idProduct          = 0x4021,
 	.bcdDevice          = 0x0101,
 
 	.iManufacturer      = 0x01,

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -56,7 +56,6 @@ void GP2040::setup() {
 			gamepad->options.inputMode = inputMode;
 			gamepad->save();
 		}
-		initialize_driver(inputMode);
 	}
 
 	// Setup Add-ons

--- a/src/gp2040.cpp
+++ b/src/gp2040.cpp
@@ -56,6 +56,7 @@ void GP2040::setup() {
 			gamepad->options.inputMode = inputMode;
 			gamepad->save();
 		}
+		initialize_driver(inputMode);
 	}
 
 	// Setup Add-ons


### PR DESCRIPTION
The problem lied in the RNDIS descriptor, the interface string was missing.