### PR TITLE
Add startup delay for unreliable oscillator

### DIFF
--- a/configs/FlatboxRev4/env.ini
+++ b/configs/FlatboxRev4/env.ini
@@ -2,4 +2,5 @@
 upload_port = .pio/build/flatbox-rev-4/
 build_flags =
 	${env.build_flags}
+	-D PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 	-I configs/FlatboxRev4/

--- a/configs/FlatboxRev5/env.ini
+++ b/configs/FlatboxRev5/env.ini
@@ -2,4 +2,5 @@
 upload_port = .pio/build/flatbox-rev-5/
 build_flags =
 	${env.build_flags}
+	-D PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 	-I configs/FlatboxRev5/


### PR DESCRIPTION
See jfedor2/flatbox@14c4064a44eff1afe67dacc6285b9cdd62a9a09e

Passing defines directly to compiler since it seems GP2040's BoardConfig.h loading:
https://github.com/OpenStickFoundation/GP2040-CE/blob/main/src/gp2040.cpp#L3
https://github.com/OpenStickFoundation/GP2040-CE/blob/main/include/helper.h#L7

might occur after Main's already brought in some Pico headers:
https://github.com/OpenStickFoundation/GP2040-CE/blob/main/src/main.cpp#L7

and we're trying to override:
https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_xosc/include/hardware/xosc.h#L17
