### PR TITLE
Firmware version served from API route

### DIFF
--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -31,6 +31,7 @@
 #define API_SET_PIN_MAPPINGS "/api/setPinMappings"
 #define API_GET_ADDON_OPTIONS "/api/getAddonsOptions"
 #define API_SET_ADDON_OPTIONS "/api/setAddonsOptions"
+#define API_GET_FIRMWARE_VERSION "/api/getFirmwareVersion"
 
 #define LWIP_HTTPD_POST_MAX_URI_LEN 128
 #define LWIP_HTTPD_POST_MAX_PAYLOAD_LEN 2048
@@ -460,6 +461,14 @@ std::string getAddonOptions()
 	return serialize_json(doc);
 }
 
+std::string getFirmwareVersion()
+{
+	DynamicJsonDocument doc(LWIP_HTTPD_POST_MAX_PAYLOAD_LEN);
+	doc["version"] = GP2040VERSION;
+
+	return serialize_json(doc);
+}
+
 // This should be a storage feature
 std::string resetSettings()
 {
@@ -498,6 +507,8 @@ int fs_open_custom(struct fs_file *file, const char *name)
 			return set_file_data(file, getAddonOptions());
 		if (!memcmp(name, API_RESET_SETTINGS, sizeof(API_RESET_SETTINGS)))
 			return set_file_data(file, resetSettings());
+		if (!memcmp(name, API_GET_FIRMWARE_VERSION, sizeof(API_GET_FIRMWARE_VERSION)))
+			return set_file_data(file, getFirmwareVersion());
 	}
 
 	bool isExclude = false;

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -141,6 +141,13 @@ app.get('/api/getAddonsOptions', (req, res) => {
 	});
 });
 
+app.get('/api/getFirmwareVersion', (req, res) => {
+	console.log('/api/getFirmwareVersion');
+	return res.send({
+		version: '0.5.X',
+	});
+});
+
 app.post('/api/*', (req, res) => {
 	console.log(req.url);
 	return res.send(req.body);

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -144,7 +144,7 @@ app.get('/api/getAddonsOptions', (req, res) => {
 app.get('/api/getFirmwareVersion', (req, res) => {
 	console.log('/api/getFirmwareVersion');
 	return res.send({
-		version: '0.5.X',
+		version: process.env.REACT_APP_CURRENT_VERSION,
 	});
 });
 

--- a/www/src/Pages/HomePage.js
+++ b/www/src/Pages/HomePage.js
@@ -4,13 +4,19 @@ import { orderBy } from 'lodash';
 
 import Section from '../Components/Section';
 
-const currentVersion = process.env.REACT_APP_CURRENT_VERSION;
+import WebApi from '../Services/WebApi';
 
 export default function HomePage() {
 	const [latestVersion, setLatestVersion] = useState('');
 	const [latestTag, setLatestTag] = useState('');
+	const [currentVersion, setCurrentVersion] = useState(process.env.REACT_APP_CURRENT_VERSION);
 
 	useEffect(() => {
+		WebApi.getFirmwareVersion().then(response => {
+			setCurrentVersion(response.version);
+		})
+		.catch(console.error);
+		
 		axios.get('https://api.github.com/repos/OpenStickFoundation/GP2040-CE/releases')
 			.then((response) => {
 				const sortedData = orderBy(response.data, 'published_at', 'desc');

--- a/www/src/Services/WebApi.js
+++ b/www/src/Services/WebApi.js
@@ -139,6 +139,12 @@ async function setAddonsOptions(options) {
 		});
 }
 
+async function getFirmwareVersion() {
+	return axios.get(`${baseUrl}/api/getFirmwareVersion`)
+		.then((response) => response.data)
+		.catch(console.error);
+}
+
 const WebApi = {
 	resetSettings,
 	getDisplayOptions,
@@ -150,7 +156,8 @@ const WebApi = {
 	getPinMappings,
 	setPinMappings,
 	getAddonsOptions,
-	setAddonsOptions
+	setAddonsOptions,
+	getFirmwareVersion
 };
 
 export default WebApi;


### PR DESCRIPTION
I believe this commit solves #83.
Current default in the React app is the same env variable, however. Please suggest what to put, although it doesn't impact much now.

Please review and suggest changes or merge.
Thank you. 