### PR TITLE
feat(addon): direct LED addon

### DIFF
--- a/configs/PicoFightingBoard/BoardConfig.h
+++ b/configs/PicoFightingBoard/BoardConfig.h
@@ -112,12 +112,17 @@
 // 2 - `PLED_TYPE_PWM` - This will enable the Player LEDs ( it is recommended to run through 3V3(OUT) with a resistor)
 // 3 - `PLED_TYPE_RGB` - This will enable the Player LEDs as addressible RGB LEDs (please not that this has not been implemented yet)
 
-#define PLED_TYPE PLED_TYPE_PWM
-#define PLED1_PIN 16
-#define PLED2_PIN 17
-#define PLED3_PIN 18
-#define PLED4_PIN 19
+#define PLED_TYPE PLED_TYPE_NONE
+#define PLED1_PIN -1
+#define PLED2_PIN -1
+#define PLED3_PIN -1
+#define PLED4_PIN -1
 
+#define DIRECTLED_TYPE DIRECTLED_TYPE_DIRECT
+#define DIRECTLED1_PIN 19
+#define DIRECTLED2_PIN 17
+#define DIRECTLED1_BUTTON GAMEPAD_MASK_L1
+#define DIRECTLED2_BUTTON GAMEPAD_MASK_R1
 
 // This is the Analog section.
 // In this section you can specify if Analog is enabled, and, if endabled, which pins will be used for it.

--- a/include/addons/directleds.h
+++ b/include/addons/directleds.h
@@ -1,0 +1,106 @@
+#ifndef _DirectLEDs_H
+#define _DirectLEDs_H
+
+#include "gpaddon.h"
+
+#include "GamepadEnums.h"
+
+typedef enum
+{
+    DIRECTLED_TYPE_NONE = -1,
+    DIRECTLED_TYPE_DIRECT = 0,
+} DirectLEDType;
+
+#define DIRECTLED_COUNT 4
+
+#ifndef DIRECTLED_TYPE
+#define DIRECTLED_TYPE DIRECTLED_TYPE_NONE
+#endif
+
+#ifndef DIRECTLED1_PIN
+#define DIRECTLED1_PIN -1
+#endif
+
+#ifndef DIRECTLED2_PIN
+#define DIRECTLED2_PIN -1
+#endif
+
+#ifndef DIRECTLED3_PIN
+#define DIRECTLED3_PIN -1
+#endif
+
+#ifndef DIRECTLED4_PIN
+#define DIRECTLED4_PIN -1
+#endif
+
+#ifndef DIRECTLED1_BUTTON
+#define DIRECTLED1_BUTTON 0
+#endif
+
+#ifndef DIRECTLED2_BUTTON
+#define DIRECTLED2_BUTTON 0
+#endif
+
+#ifndef DIRECTLED3_BUTTON
+#define DIRECTLED3_BUTTON 0
+#endif
+
+#ifndef DIRECTLED4_BUTTON
+#define DIRECTLED4_BUTTON 0
+#endif
+
+#ifndef DIRECTLED1_DPAD
+#define DIRECTLED1_DPAD 0
+#endif
+
+#ifndef DIRECTLED2_DPAD
+#define DIRECTLED2_DPAD 0
+#endif
+
+#ifndef DIRECTLED3_DPAD
+#define DIRECTLED3_DPAD 0
+#endif
+
+#ifndef DIRECTLED4_DPAD
+#define DIRECTLED4_DPAD 0
+#endif
+
+#if DIRECTLED1_BUTTON != 0 && DIRECTLED1_DPAD != 0
+#error Cannot map Direct LED1 to both dpad and button
+#endif
+
+#if DIRECTLED2_BUTTON != 0 && DIRECTLED2_DPAD != 0
+#error Cannot map Direct LED2 to both dpad and button
+#endif
+
+#if DIRECTLED3_BUTTON != 0 && DIRECTLED3_DPAD != 0
+#error Cannot map Direct LED3 to both dpad and button
+#endif
+
+#if DIRECTLED4_BUTTON != 0 && DIRECTLED4_DPAD != 0
+#error Cannot map Direct LED4 to both dpad and button
+#endif
+
+// Button Mask
+#define DIRECTLED_BUTTON_MASK (GAMEPAD_MASK_B1 | GAMEPAD_MASK_B2 | GAMEPAD_MASK_B3 | GAMEPAD_MASK_B4 | \
+                               GAMEPAD_MASK_L1 | GAMEPAD_MASK_R1 | GAMEPAD_MASK_L2 | GAMEPAD_MASK_R2)
+
+const int DIRECTLED_PINS[] = {DIRECTLED1_PIN, DIRECTLED2_PIN, DIRECTLED3_PIN, DIRECTLED4_PIN};
+const int DIRECTLED_BUTTONMAP[] = {DIRECTLED1_BUTTON, DIRECTLED2_BUTTON, DIRECTLED3_BUTTON, DIRECTLED4_BUTTON};
+const int DIRECTLED_DPADMAP[] = {DIRECTLED1_DPAD, DIRECTLED2_DPAD, DIRECTLED3_DPAD, DIRECTLED4_DPAD};
+
+// Direct LED Module Name
+#define DirectLedName "Direct LEDs"
+
+class DirectLEDAddon : public GPAddon
+{
+public:
+    virtual bool available(); // GPAddon available
+    virtual void setup();     // DirectLED Setup
+    virtual void process();   // DirectLED Process
+    virtual std::string name() { return DirectLedName; }
+
+private:
+};
+
+#endif // _DirectLEDs_H_

--- a/include/storagemanager.h
+++ b/include/storagemanager.h
@@ -72,6 +72,18 @@ struct BoardOptions
 	int i2cAnalog1219Block;
 	uint32_t i2cAnalog1219Speed;
 	uint8_t i2cAnalog1219Address;
+	uint8_t directLed1Pin;
+	uint8_t directLed2Pin;
+	uint8_t directLed3Pin;
+	uint8_t directLed4Pin;
+	uint16_t directLed1Button;
+	uint16_t directLed2Button;
+	uint16_t directLed3Button;
+	uint16_t directLed4Button;
+	uint8_t directLed1Dpad;
+	uint8_t directLed2Dpad;
+	uint8_t directLed3Dpad;
+	uint8_t directLed4Dpad;
 	char boardVersion[32]; // 32-char limit to board name
 	uint32_t checksum;
 };

--- a/src/addons/directleds.cpp
+++ b/src/addons/directleds.cpp
@@ -1,0 +1,42 @@
+#include "addons/directleds.h"
+#include "storagemanager.h"
+
+bool DirectLEDAddon::available()
+{
+    return DIRECTLED_TYPE != DIRECTLED_TYPE_NONE;
+}
+
+void DirectLEDAddon::setup()
+{
+    for (int i = 0; i < DIRECTLED_COUNT; i++)
+    {
+        int p = DIRECTLED_PINS[i];
+        if (p != -1)
+        {
+            gpio_init(p);
+            gpio_set_dir(p, GPIO_OUT);
+            gpio_put(p, 0); // default off
+        }
+    }
+}
+
+void DirectLEDAddon::process()
+{
+    Gamepad *gamepad = Storage::getInstance().GetGamepad();
+    uint16_t buttonsPressed = gamepad->state.buttons & DIRECTLED_BUTTON_MASK;
+    uint16_t dpadPressed = gamepad->state.dpad & GAMEPAD_MASK_DPAD;
+
+    for (int i = 0; i < DIRECTLED_COUNT; i++)
+    {
+        int p = DIRECTLED_PINS[i];
+        int b = DIRECTLED_BUTTONMAP[i];
+        int d = DIRECTLED_DPADMAP[i];
+
+        if (p == -1)
+            continue;
+
+        int ledVal = ((buttonsPressed & b) || (dpadPressed & d));
+
+        gpio_put(p, ledVal);
+    }
+}

--- a/src/configs/webconfig.cpp
+++ b/src/configs/webconfig.cpp
@@ -452,6 +452,18 @@ std::string setAddonOptions()
 	boardOptions.i2cAnalog1219Block = doc["i2cAnalog1219Block"];
 	boardOptions.i2cAnalog1219Speed = doc["i2cAnalog1219Speed"];
 	boardOptions.i2cAnalog1219Address = doc["i2cAnalog1219Address"];
+	boardOptions.directLed1Pin        = doc["directLed1Pin"] == -1 ? 0xFF : doc["directLed1Pin"];
+	boardOptions.directLed1Button     = doc["directLed1Button"];
+	boardOptions.directLed1Dpad       = doc["directLed1Dpad"];
+	boardOptions.directLed2Pin        = doc["directLed2Pin"] == -1 ? 0xFF : doc["directLed2Pin"];
+	boardOptions.directLed2Button     = doc["directLed2Button"];
+	boardOptions.directLed2Dpad       = doc["directLed2Dpad"];
+	boardOptions.directLed3Pin        = doc["directLed3Pin"] == -1 ? 0xFF : doc["directLed3Pin"];
+	boardOptions.directLed3Button     = doc["directLed3Button"];
+	boardOptions.directLed3Dpad       = doc["directLed3Dpad"];
+	boardOptions.directLed4Pin        = doc["directLed4Pin"] == -1 ? 0xFF : doc["directLed4Pin"];
+	boardOptions.directLed4Button     = doc["directLed4Button"];
+	boardOptions.directLed4Dpad       = doc["directLed4Dpad"];
 	Storage::getInstance().setBoardOptions(boardOptions);
 
 	return serialize_json(doc);
@@ -477,6 +489,18 @@ std::string getAddonOptions()
 	doc["i2cAnalog1219Block"] = boardOptions.i2cAnalog1219Block;
 	doc["i2cAnalog1219Speed"] = boardOptions.i2cAnalog1219Speed;
 	doc["i2cAnalog1219Address"] = boardOptions.i2cAnalog1219Address;
+	doc["directLed1Pin"]    = boardOptions.directLed1Pin == 0xFF ? -1 : boardOptions.directLed1Pin;
+	doc["directLed1Button"] = boardOptions.directLed1Button;
+	doc["directLed1Dpad"]   = boardOptions.directLed1Dpad;
+	doc["directLed2Pin"]    = boardOptions.directLed2Pin == 0xFF ? -1 : boardOptions.directLed2Pin;
+	doc["directLed2Button"] = boardOptions.directLed2Button;
+	doc["directLed2Dpad"]   = boardOptions.directLed2Dpad;
+	doc["directLed3Pin"]    = boardOptions.directLed3Pin == 0xFF ? -1 : boardOptions.directLed3Pin;
+	doc["directLed3Button"] = boardOptions.directLed3Button;
+	doc["directLed3Dpad"]   = boardOptions.directLed3Dpad;
+	doc["directLed4Pin"]    = boardOptions.directLed4Pin == 0xFF ? -1 : boardOptions.directLed4Pin;
+	doc["directLed4Button"] = boardOptions.directLed4Button;
+	doc["directLed4Dpad"]   = boardOptions.directLed4Dpad;
 
 	Gamepad * gamepad = Storage::getInstance().GetGamepad();
 	auto usedPins = doc.createNestedArray("usedPins");

--- a/src/gp2040aux.cpp
+++ b/src/gp2040aux.cpp
@@ -8,6 +8,7 @@
 #include "addons/i2cdisplay.h" // Add-Ons
 #include "addons/neopicoleds.h"
 #include "addons/playerleds.h"
+#include "addons/directleds.h"
 
 #include <iterator>
 
@@ -21,6 +22,7 @@ void GP2040Aux::setup() {
 	addons.LoadAddon(new I2CDisplayAddon(), CORE1_LOOP);
 	addons.LoadAddon(new NeoPicoLEDAddon(), CORE1_LOOP);
 	addons.LoadAddon(new PlayerLEDAddon(), CORE1_LOOP);
+	addons.LoadAddon(new DirectLEDAddon(), CORE1_LOOP);
 }
 
 void GP2040Aux::run() {

--- a/src/storagemanager.cpp
+++ b/src/storagemanager.cpp
@@ -20,6 +20,7 @@
 #include "addons/playerleds.h"
 #include "addons/i2canalog1219.h"
 #include "addons/turbo.h"
+#include "addons/directleds.h"
 
 #include "bitmaps.h"
 
@@ -100,6 +101,18 @@ void Storage::setDefaultBoardOptions()
 	boardOptions.i2cAnalog1219Block      = (I2C_ANALOG1219_BLOCK == i2c0) ? 0 : 1;
 	boardOptions.i2cAnalog1219Speed      = I2C_ANALOG1219_SPEED;
 	boardOptions.i2cAnalog1219Address    = I2C_ANALOG1219_ADDRESS;
+	boardOptions.directLed1Pin           = DIRECTLED1_PIN;
+	boardOptions.directLed1Button        = DIRECTLED1_BUTTON;
+	boardOptions.directLed1Dpad          = DIRECTLED1_DPAD;
+	boardOptions.directLed2Pin           = DIRECTLED2_PIN;
+	boardOptions.directLed2Button        = DIRECTLED2_BUTTON;
+	boardOptions.directLed2Dpad          = DIRECTLED2_DPAD;
+	boardOptions.directLed3Pin           = DIRECTLED3_PIN;
+	boardOptions.directLed3Button        = DIRECTLED3_BUTTON;
+	boardOptions.directLed3Dpad          = DIRECTLED3_DPAD;
+	boardOptions.directLed4Pin           = DIRECTLED4_PIN;
+	boardOptions.directLed4Button        = DIRECTLED4_BUTTON;
+	boardOptions.directLed4Dpad          = DIRECTLED4_DPAD;
 	strncpy(boardOptions.boardVersion, GP2040VERSION, strlen(GP2040VERSION));
 	setBoardOptions(boardOptions);
 }

--- a/www/server/app.js
+++ b/www/server/app.js
@@ -149,6 +149,18 @@ app.get('/api/getAddonsOptions', (req, res) => {
 		i2cAnalog1219Block: 0,
 		i2cAnalog1219Speed: 400000,
 		i2cAnalog1219Address: 0x40,
+		directLed1Pin: -1,
+		directLed1Button: 0,
+		directLed1Dpad: 0,
+		directLed2Pin: -1,
+		directLed2Button: 0,
+		directLed2Dpad: 0,
+		directLed3Pin: -1,
+		directLed3Button: 0,
+		directLed3Dpad: 0,
+		directLed4Pin: -1,
+		directLed4Button: 0,
+		directLed4Dpad: 0,
 		usedPins,
 	});
 });

--- a/www/src/Pages/AddonsConfigPage.js
+++ b/www/src/Pages/AddonsConfigPage.js
@@ -12,6 +12,33 @@ const I2C_BLOCKS = [
 	{ label: 'i2c1', value: 1 },
 ];
 
+
+const BUTTON_MAP = [
+	{ label: '<none>', value: 0 },
+	{ label: 'B1', value: 1 << 0 },
+	{ label: 'B2', value: 1 << 1 },
+	{ label: 'B3', value: 1 << 2 },
+	{ label: 'B4', value: 1 << 3 },
+	{ label: 'L1', value: 1 << 4 },
+	{ label: 'R1', value: 1 << 5 },
+	{ label: 'L2', value: 1 << 6 },
+	{ label: 'R2', value: 1 << 7 },
+	{ label: 'S1', value: 1 << 8 },
+	{ label: 'S2', value: 1 << 9 },
+	{ label: 'L3', value: 1 << 10 },
+	{ label: 'R3', value: 1 << 11 },
+	{ label: 'A1', value: 1 << 12 },
+	{ label: 'A2', value: 1 << 13 },
+];
+
+const DPAD_MAP = [
+	{ label: '<none>', value: 0 },
+	{ label: 'Up', value: 1 << 0 },
+	{ label: 'Down', value: 1 << 1 },
+	{ label: 'Left', value: 1 << 2 },
+	{ label: 'Right', value: 1 << 3 },
+]
+
 const schema = yup.object().shape({
 	turboPin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Turbo Pin'),
 	turboPinLED: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Turbo Pin LED'),
@@ -25,6 +52,18 @@ const schema = yup.object().shape({
 	i2cAnalog1219Block: yup.number().required().oneOf(I2C_BLOCKS.map(o => o.value)).label('I2C Analog1219 Block'),
 	i2cAnalog1219Speed: yup.number().required().label('I2C Analog1219 Speed'),
 	i2cAnalog1219Address: yup.number().required().label('I2C Analog1219 Address'),
+	directLed1Pin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Direct LED Pin #1'),
+	directLed2Pin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Direct LED Pin #2'),
+	directLed3Pin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Direct LED Pin #3'),
+	directLed4Pin: yup.number().required().min(-1).max(29).test('', '${originalValue} is already assigned!', (value) => usedPins.indexOf(value) === -1).label('Direct LED Pin #4'),
+	directLed1Button: yup.number().required().oneOf(BUTTON_MAP.map(o => o.value)).label('Direct LED #1 Button'),
+	directLed2Button: yup.number().required().oneOf(BUTTON_MAP.map(o => o.value)).label('Direct LED #2 Button'),
+	directLed3Button: yup.number().required().oneOf(BUTTON_MAP.map(o => o.value)).label('Direct LED #3 Button'),
+	directLed4Button: yup.number().required().oneOf(BUTTON_MAP.map(o => o.value)).label('Direct LED #4 Button'),
+	directLed1Dpad: yup.number().required().oneOf(DPAD_MAP.map(o => o.value)).label('Direct LED #1 Dpad'),
+	directLed2Dpad: yup.number().required().oneOf(DPAD_MAP.map(o => o.value)).label('Direct LED #2 Dpad'),
+	directLed3Dpad: yup.number().required().oneOf(DPAD_MAP.map(o => o.value)).label('Direct LED #3 Dpad'),
+	directLed4Dpad: yup.number().required().oneOf(DPAD_MAP.map(o => o.value)).label('Direct LED #4 Dpad'),
 });
 
 const defaultValues = {
@@ -40,6 +79,18 @@ const defaultValues = {
 	i2cAnalog1219Block: 0,
 	i2cAnalog1219Speed: 400000,
 	i2cAnalog1219Address: 0x40,
+	directLed1Pin: -1,
+	directLed2Pin: -1,
+	directLed3Pin: -1,
+	directLed4Pin: -1,
+	directLed1Button: 0,
+	directLed2Button: 0,
+	directLed3Button: 0,
+	directLed4Button: 0,
+	directLed1Dpad: 0,
+	directLed2Dpad: 0,
+	directLed3Dpad: 0,
+	directLed4Dpad: 0,
 };
 
 const REVERSE_ACTION = [
@@ -95,6 +146,32 @@ const FormContext = () => {
 			values.i2cAnalog1219Speed = parseInt(values.i2cAnalog1219Speed);
 		if (!!values.i2cAnalog1219Address)
 			values.i2cAnalog1219Address = parseInt(values.i2cAnalog1219Address);
+		if (!!values.directLed1Pin)
+			values.directLed1Pin = parseInt(values.directLed1Pin);
+		if (!!values.directLed2Pin)
+			values.directLed2Pin = parseInt(values.directLed2Pin);
+		if (!!values.directLed3Pin)
+			values.directLed3Pin = parseInt(values.directLed3Pin);
+		if (!!values.directLed4Pin)
+			values.directLed4Pin = parseInt(values.directLed4Pin);
+		if (!!values.directLed1Button)
+			values.directLed1Button = parseInt(values.directLed1Button);
+		if (!!values.directLed2Button)
+			values.directLed2Button = parseInt(values.directLed2Button);
+		if (!!values.directLed3Button)
+			values.directLed3Button = parseInt(values.directLed3Button);
+		if (!!values.directLed4Button)
+			values.directLed4Button = parseInt(values.directLed4Button);
+		if (!!values.directLed1Dpad)
+			values.directLed1Dpad = parseInt(values.directLed1Dpad);
+		if (!!values.directLed2Dpad)
+			values.directLed2Dpad = parseInt(values.directLed2Dpad);
+		if (!!values.directLed3Dpad)
+			values.directLed3Dpad = parseInt(values.directLed3Dpad);
+		if (!!values.directLed4Dpad)
+			values.directLed4Dpad = parseInt(values.directLed4Dpad);
+
+
 	}, [values, setValues]);
 
 	return null;
@@ -109,7 +186,7 @@ export default function AddonsConfigPage() {
 	};
 
 	return (
-	<Formik validationSchema={schema} onSubmit={onSuccess} initialValues={defaultValues}>
+		<Formik validationSchema={schema} onSubmit={onSuccess} initialValues={defaultValues}>
 			{({
 				handleSubmit,
 				handleChange,
@@ -327,6 +404,154 @@ export default function AddonsConfigPage() {
 								onChange={handleChange}
 								maxLength={4}
 							/>
+						</Col>
+					</Section>
+					<Section title="Direct LEDs">
+						<Col>
+							<FormControl type="number"
+								label="Direct LED #1 Pin"
+								name="directLed1Pin"
+								className="form-control-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed1Pin}
+								error={errors.directLed1Pin}
+								isInvalid={errors.directLed1Pin}
+								onChange={handleChange}
+								min={-1}
+								max={29}
+							/>
+							<FormSelect
+								label="Direct LED #1 Button"
+								name="directLed1Button"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed1Button}
+								error={errors.directLed1Button}
+								isInvalid={errors.directLed1Button}
+								onChange={handleChange}
+							>
+								{BUTTON_MAP.map((o, i) => <option key={`direct-led-button-1-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Direct LED #1 DPad"
+								name="directLed1Dpad"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed1Dpad}
+								error={errors.directLed1Dpad}
+								isInvalid={errors.directLed1Dpad}
+								onChange={handleChange}
+							>
+								{DPAD_MAP.map((o, i) => <option key={`direct-led-dpad-1-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormControl type="number"
+								label="Direct LED #2 Pin"
+								name="directLed2Pin"
+								className="form-control-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed2Pin}
+								error={errors.directLed2Pin}
+								isInvalid={errors.directLed2Pin}
+								onChange={handleChange}
+								min={-1}
+								max={29}
+							/>
+							<FormSelect
+								label="Direct LED #2 Button"
+								name="directLed2Button"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed2Button}
+								error={errors.directLed2Button}
+								isInvalid={errors.directLed2Button}
+								onChange={handleChange}
+							>
+								{BUTTON_MAP.map((o, i) => <option key={`direct-led-button-2-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Direct LED #2 DPad"
+								name="directLed2Dpad"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed2Dpad}
+								error={errors.directLed2Dpad}
+								isInvalid={errors.directLed2Dpad}
+								onChange={handleChange}
+							>
+								{DPAD_MAP.map((o, i) => <option key={`direct-led-dpad-2-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormControl type="number"
+								label="Direct LED #3 Pin"
+								name="directLed3Pin"
+								className="form-control-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed3Pin}
+								error={errors.directLed3Pin}
+								isInvalid={errors.directLed3Pin}
+								onChange={handleChange}
+								min={-1}
+								max={29}
+							/>
+							<FormSelect
+								label="Direct LED #3 Button"
+								name="directLed3Button"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed3Button}
+								error={errors.directLed3Button}
+								isInvalid={errors.directLed3Button}
+								onChange={handleChange}
+							>
+								{BUTTON_MAP.map((o, i) => <option key={`direct-led-button-3-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Direct LED #3 DPad"
+								name="directLed3Dpad"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed3Dpad}
+								error={errors.directLed3Dpad}
+								isInvalid={errors.directLed3Dpad}
+								onChange={handleChange}
+							>
+								{DPAD_MAP.map((o, i) => <option key={`direct-led-dpad-3-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormControl type="number"
+								label="Direct LED #4 Pin"
+								name="directLed4Pin"
+								className="form-control-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed4Pin}
+								error={errors.directLed4Pin}
+								isInvalid={errors.directLed4Pin}
+								onChange={handleChange}
+								min={-1}
+								max={29}
+							/>
+							<FormSelect
+								label="Direct LED #4 Button"
+								name="directLed4Button"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed4Button}
+								error={errors.directLed4Button}
+								isInvalid={errors.directLed4Button}
+								onChange={handleChange}
+							>
+								{BUTTON_MAP.map((o, i) => <option key={`direct-led-button-4-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
+							<FormSelect
+								label="Direct LED #4 DPad"
+								name="directLed4Dpad"
+								className="form-select-sm"
+								groupClassName="col-sm-3 mb-3"
+								value={values.directLed4Dpad}
+								error={errors.directLed4Dpad}
+								isInvalid={errors.directLed4Dpad}
+								onChange={handleChange}
+							>
+								{DPAD_MAP.map((o, i) => <option key={`direct-led-dpad-4-option-${i}`} value={o.value}>{o.label}</option>)}
+							</FormSelect>
 						</Col>
 					</Section>
 					<div className="mt-3">


### PR DESCRIPTION
Support driving up to 4 single-pin LEDs, mapped to single button events

For sure the addressable LEDs are better in most cases, but if you have only 1-2 buttons that need lit, or you are working with some specific arcade hardware, it can be easier to direct-drive those LEDs with simple `gpio_put(0/1)`.